### PR TITLE
Rules for //:kustomize //:gcloud //:kubectl use :execpwd.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,13 +10,20 @@ filegroup(
     srcs = ["exec.sh"],
 )
 
-sh_binary(
-    name = "kustomize",
-    srcs = ["@kustomize//:file"],
+filegroup(
+    name = "execpwd",
+    srcs = ["execpwd.sh"],
 )
 
 sh_binary(
-    name = "kubectl",
+    name = "kustomize",
+    srcs = [":execpwd"],
+    args = ["$(location @kustomize//:file)"],
+    data = ["@kustomize//:file"],
+)
+
+sh_binary(
+    name = "kubectl_bin",
     srcs = select({
         "@bazel_tools//src/conditions:linux_x86_64": ["@kubectl_linux//file"],
         "@bazel_tools//src/conditions:darwin": ["@kubectl_darwin//file"],
@@ -24,8 +31,17 @@ sh_binary(
 )
 
 sh_binary(
+    name = "kubectl",
+    srcs = [":execpwd"],
+    args = ["$(location :kubectl_bin)"],
+    data = [":kubectl_bin"],
+)
+
+sh_binary(
     name = "gcloud",
-    srcs = ["@gcloud"],
+    srcs = [":execpwd"],
+    args = ["$(location @gcloud)"],
+    data = ["@gcloud"],
 )
 
 # Exported for documentation (see //tools:docs).

--- a/execpwd.sh
+++ b/execpwd.sh
@@ -13,4 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec "$@"
+# See https://github.com/bazelbuild/bazel/issues/3325
+if [ -z "${BUILD_WORKING_DIRECTORY-}" ]; then
+  echo "error BUILD_WORKING_DIRECTORY not set"
+  exit 1
+fi
+
+cmd="$( pwd )/${1}"
+cd "${BUILD_WORKING_DIRECTORY}"
+shift
+
+exec "${cmd}" "$@"


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/3325

Tested:

    mkdir examples/tmp
    cd examples/tmp
    bazel run @com_benchsci_rules_kustomize//:kustomize -- create

Confirm a `kustomize.yaml` file is created in the working directory.
Previously, the tool would mutate the underlying runfiles directory.