### PR TITLE
Fix fixgolden.sh to work from anywhere in a workspace.

### DIFF
--- a/fixgolden.sh
+++ b/fixgolden.sh
@@ -17,6 +17,6 @@ set -euxo pipefail
 
 while(($#)); do
   SOURCE=$1 && shift
-  GOLDEN="${BUILD_WORKING_DIRECTORY}/$( dirname "${SOURCE}" )/$1" && shift
+  GOLDEN="${BUILD_WORKSPACE_DIRECTORY}/$( dirname "${SOURCE}" )/$1" && shift
   cat "$SOURCE" > "$GOLDEN"
 done


### PR DESCRIPTION
Incorrect usage of BUILD_WORKING_DIRECTORY (should have been
BUILD_WORKSPACE_DIRECTORY).