### PR TITLE
Make sh_binary targets public.

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -70,6 +70,8 @@ def _base_cmd(cfg, src, namespace, tags, subcmd, *extra_args):
         ],
         tags = tags,
         args = args,
+        # Required to allow aliasing run targets.
+        visibility = ["//visibility:public"],
     )
 
 def apply(name, src, cfg, namespace = None, tags = None):


### PR DESCRIPTION
This is an ergonomic change to allow defining shorter aliases
(https://docs.bazel.build/versions/main/be/general.html#alias) for the
various sh_binary targets that may be quite long/verbose.